### PR TITLE
fix: improve typescript LSP performance

### DIFF
--- a/libs/prisma/types/src/lib/types/ArtifactDTO.ts
+++ b/libs/prisma/types/src/lib/types/ArtifactDTO.ts
@@ -1,6 +1,75 @@
+import {
+  ArtifactAccessLevel,
+  ArtifactTheme,
+  ArtifactType,
+} from '@prisma/client';
 import type { ArtifactDetail } from './artifactDetail';
 
-export type ArtifactDTO = Omit<ArtifactDetail, 'text' | 'artifactPins'> & {
+type ExpectedType = Omit<ArtifactDetail, 'text' | 'artifactPins'> & {
   isPinned: boolean;
   previewText: string;
 };
+
+export type ArtifactDTO = {
+  id: string;
+  title: string;
+  type: ArtifactType;
+  theme: ArtifactTheme;
+  userId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  isPinned: boolean;
+  previewText: string;
+  artifactReferences: {
+    id: string;
+    artifactId: string;
+    artifactBlockId: string;
+    targetArtifactId: string;
+    targetArtifactBlockId: string | null;
+    referenceTargetArtifactId: string | null;
+    referenceText: string;
+    targetArtifactDate: string | null;
+  }[];
+  incomingArtifactReferences: {
+    id: string;
+    artifactId: string;
+    artifact: {
+      title: string;
+    };
+    artifactBlockId: string;
+    targetArtifactId: string;
+    targetArtifactBlockId: string | null;
+    targetArtifactDate: string | null;
+  }[];
+  artfactFiles: {
+    id: string;
+    fileId: string;
+    order: number;
+    file: {
+      filename: string;
+      storageKey: string;
+      mimetype: string;
+    };
+  }[];
+  artifactShares: {
+    id: string;
+    userId: string;
+    user: {
+      name: string;
+    };
+    accessLevel: ArtifactAccessLevel;
+  }[];
+  artifactShareTokens: {
+    id: string;
+    shareToken: string;
+    allowAddToAccount: boolean;
+    accessLevel: ArtifactAccessLevel;
+  }[];
+  user: {
+    name: string;
+  };
+};
+
+// Check type inference between our static type and Prisma's dynamic type
+const _ = {} as ArtifactDTO satisfies ExpectedType;
+const __ = {} as ExpectedType satisfies ArtifactDTO;

--- a/libs/search/src/index.ts
+++ b/libs/search/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/search';
+export { BlockIndexDocument } from './lib/types';

--- a/libs/trpc/src/lib/router/ai/createThread.ts
+++ b/libs/trpc/src/lib/router/ai/createThread.ts
@@ -8,9 +8,20 @@ export const createThread = authenticatedProcedure
       title: z.string().optional(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
-    const threads = await prisma.thread.create({
-      data: { userId: ctx.session.userId, title: input.title || undefined },
-    });
-    return threads;
-  });
+  .mutation(
+    async ({
+      ctx,
+      input,
+    }): Promise<{
+      id: string;
+      title: string | null;
+      userId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    }> => {
+      const threads = await prisma.thread.create({
+        data: { userId: ctx.session.userId, title: input.title || undefined },
+      });
+      return threads;
+    },
+  );

--- a/libs/trpc/src/lib/router/ai/createThreadTitle.ts
+++ b/libs/trpc/src/lib/router/ai/createThreadTitle.ts
@@ -12,7 +12,7 @@ export const createThreadTitle = authenticatedProcedure
       id: z.string(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
+  .mutation(async ({ ctx, input }): Promise<string> => {
     const thread = await prisma.thread.findFirst({
       where: { id: input.id, userId: ctx.session.userId },
       ...threadSummary,

--- a/libs/trpc/src/lib/router/ai/deleteMessageUntil.ts
+++ b/libs/trpc/src/lib/router/ai/deleteMessageUntil.ts
@@ -10,7 +10,7 @@ export const deleteMessageUntil = authenticatedProcedure
       threadId: z.string(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
+  .mutation(async ({ ctx, input }): Promise<string> => {
     const thread = await prisma.thread.findFirst({
       where: { id: input.threadId, userId: ctx.session.userId },
     });

--- a/libs/trpc/src/lib/router/ai/deleteThread.ts
+++ b/libs/trpc/src/lib/router/ai/deleteThread.ts
@@ -9,7 +9,7 @@ export const deleteThread = authenticatedProcedure
       id: z.string(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
+  .mutation(async ({ ctx, input }): Promise<void> => {
     const thread = await prisma.thread.delete({
       where: { id: input.id, userId: ctx.session.userId },
     });

--- a/libs/trpc/src/lib/router/ai/saveMessage.ts
+++ b/libs/trpc/src/lib/router/ai/saveMessage.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { authenticatedProcedure } from '../../middleware/authenticatedProcedure';
 import { prisma } from '@feynote/prisma/client';
+import { JsonValue } from '@prisma/client/runtime/library';
 
 export const saveMessage = authenticatedProcedure
   .input(
@@ -9,9 +10,19 @@ export const saveMessage = authenticatedProcedure
       message: z.any(),
     }),
   )
-  .mutation(async ({ input }) => {
-    const message = await prisma.message.create({
-      data: { threadId: input.threadId, json: input.message },
-    });
-    return message;
-  });
+  .mutation(
+    async ({
+      input,
+    }): Promise<{
+      id: string;
+      json: JsonValue;
+      threadId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    }> => {
+      const message = await prisma.message.create({
+        data: { threadId: input.threadId, json: input.message },
+      });
+      return message;
+    },
+  );

--- a/libs/trpc/src/lib/router/ai/updateThread.ts
+++ b/libs/trpc/src/lib/router/ai/updateThread.ts
@@ -10,17 +10,28 @@ export const updateThread = authenticatedProcedure
       title: z.string(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
-    const thread = await prisma.thread.update({
-      where: { id: input.id, userId: ctx.session.userId },
-      data: {
-        title: input.title,
-      },
-    });
-    if (!thread) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
+  .mutation(
+    async ({
+      ctx,
+      input,
+    }): Promise<{
+      id: string;
+      title: string | null;
+      userId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    }> => {
+      const thread = await prisma.thread.update({
+        where: { id: input.id, userId: ctx.session.userId },
+        data: {
+          title: input.title,
+        },
       });
-    }
-    return thread;
-  });
+      if (!thread) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+        });
+      }
+      return thread;
+    },
+  );

--- a/libs/trpc/src/lib/router/artifact/createArtifact.ts
+++ b/libs/trpc/src/lib/router/artifact/createArtifact.ts
@@ -18,44 +18,51 @@ export const createArtifact = authenticatedProcedure
       theme: z.nativeEnum(ArtifactTheme),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
-    const yDoc = constructYArtifact({
-      title: input.title,
-      theme: input.theme,
-      type: input.type,
-    });
-    const yBin = Buffer.from(encodeStateAsUpdate(yDoc));
-
-    const artifact = await prisma.artifact.create({
-      data: {
-        id: input.id,
+  .mutation(
+    async ({
+      ctx,
+      input,
+    }): Promise<{
+      id: string;
+    }> => {
+      const yDoc = constructYArtifact({
         title: input.title,
-        type: input.type,
-        text: input.text,
-        json: input.json,
-        userId: ctx.session.userId,
         theme: input.theme,
-        yBin,
-      },
-      select: {
-        id: true,
-        userId: true,
-      },
-    });
+        type: input.type,
+      });
+      const yBin = Buffer.from(encodeStateAsUpdate(yDoc));
 
-    await enqueueArtifactUpdate({
-      artifactId: artifact.id,
-      userId: artifact.userId,
-      triggeredByUserId: ctx.session.userId,
-      oldReadableUserIds: [ctx.session.userId],
-      newReadableUserIds: [ctx.session.userId],
-      oldYBinB64: yBin.toString('base64'),
-      newYBinB64: yBin.toString('base64'),
-    });
+      const artifact = await prisma.artifact.create({
+        data: {
+          id: input.id,
+          title: input.title,
+          type: input.type,
+          text: input.text,
+          json: input.json,
+          userId: ctx.session.userId,
+          theme: input.theme,
+          yBin,
+        },
+        select: {
+          id: true,
+          userId: true,
+        },
+      });
 
-    // We only return ID since we expect frontend to fetch artifact via getArtifactById
-    // rather than adding that logic here.
-    return {
-      id: artifact.id,
-    };
-  });
+      await enqueueArtifactUpdate({
+        artifactId: artifact.id,
+        userId: artifact.userId,
+        triggeredByUserId: ctx.session.userId,
+        oldReadableUserIds: [ctx.session.userId],
+        newReadableUserIds: [ctx.session.userId],
+        oldYBinB64: yBin.toString('base64'),
+        newYBinB64: yBin.toString('base64'),
+      });
+
+      // We only return ID since we expect frontend to fetch artifact via getArtifactById
+      // rather than adding that logic here.
+      return {
+        id: artifact.id,
+      };
+    },
+  );

--- a/libs/trpc/src/lib/router/artifact/deleteArtifact.ts
+++ b/libs/trpc/src/lib/router/artifact/deleteArtifact.ts
@@ -10,7 +10,7 @@ export const deleteArtifact = authenticatedProcedure
       id: z.string(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
+  .mutation(async ({ ctx, input }): Promise<string> => {
     const artifact = await prisma.artifact.findUnique({
       where: {
         id: input.id,

--- a/libs/trpc/src/lib/router/artifact/getArtifactById.ts
+++ b/libs/trpc/src/lib/router/artifact/getArtifactById.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { prisma } from '@feynote/prisma/client';
-import { artifactDetail, type ArtifactDetail } from '@feynote/prisma/types';
+import { artifactDetail, ArtifactDTO } from '@feynote/prisma/types';
 import {
   artifactDetailToArtifactDTO,
   hasArtifactAccess,
@@ -15,20 +15,19 @@ export const getArtifactById = publicProcedure
       shareToken: z.string().optional(),
     }),
   )
-  .query(async ({ ctx, input }) => {
+  .query(async ({ ctx, input }): Promise<ArtifactDTO> => {
     if (!ctx.session && !input.shareToken) {
       throw new TRPCError({
         code: 'UNAUTHORIZED',
       });
     }
 
-    const _artifact = await prisma.artifact.findUnique({
+    const artifact = await prisma.artifact.findUnique({
       where: {
         id: input.id,
       },
       ...artifactDetail,
     });
-    const artifact = _artifact as ArtifactDetail | undefined;
 
     if (
       !artifact ||

--- a/libs/trpc/src/lib/router/artifact/getArtifactYBinById.ts
+++ b/libs/trpc/src/lib/router/artifact/getArtifactYBinById.ts
@@ -11,55 +11,62 @@ export const getArtifactYBinById = publicProcedure
       shareToken: z.string().optional(),
     }),
   )
-  .query(async ({ input, ctx }) => {
-    if (!ctx.session && !input.shareToken) {
-      throw new TRPCError({
-        code: 'UNAUTHORIZED',
-      });
-    }
+  .query(
+    async ({
+      input,
+      ctx,
+    }): Promise<{
+      yBin: Buffer;
+    }> => {
+      if (!ctx.session && !input.shareToken) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+        });
+      }
 
-    const artifact = await prisma.artifact.findUnique({
-      where: {
-        id: input.id,
-      },
-      select: {
-        yBin: true,
-        userId: true,
-        artifactShares: {
-          select: {
-            id: true,
-            userId: true,
-            user: {
-              select: {
-                name: true,
+      const artifact = await prisma.artifact.findUnique({
+        where: {
+          id: input.id,
+        },
+        select: {
+          yBin: true,
+          userId: true,
+          artifactShares: {
+            select: {
+              id: true,
+              userId: true,
+              user: {
+                select: {
+                  name: true,
+                },
               },
+              accessLevel: true,
             },
-            accessLevel: true,
+          },
+          artifactShareTokens: {
+            select: {
+              id: true,
+              shareToken: true,
+              allowAddToAccount: true,
+              accessLevel: true,
+            },
           },
         },
-        artifactShareTokens: {
-          select: {
-            id: true,
-            shareToken: true,
-            allowAddToAccount: true,
-            accessLevel: true,
-          },
-        },
-      },
-    });
-
-    if (
-      !artifact ||
-      !hasArtifactAccess(artifact, ctx.session?.userId, input.shareToken)
-    ) {
-      throw new TRPCError({
-        message:
-          'Artifact does not exist or is not visible to the current user',
-        code: 'NOT_FOUND',
       });
-    }
 
-    return {
-      yBin: artifact.yBin,
-    };
-  });
+      if (
+        !artifact ||
+        !hasArtifactAccess(artifact, ctx.session?.userId, input.shareToken)
+      ) {
+        throw new TRPCError({
+          message:
+            'Artifact does not exist or is not visible to the current user',
+          code: 'NOT_FOUND',
+        });
+      }
+
+      return {
+        yBin: artifact.yBin,
+      };
+    },
+  );

--- a/libs/trpc/src/lib/router/artifact/getArtifacts.ts
+++ b/libs/trpc/src/lib/router/artifact/getArtifacts.ts
@@ -1,42 +1,37 @@
 import { authenticatedProcedure } from '../../middleware/authenticatedProcedure';
 import { prisma } from '@feynote/prisma/client';
-import {
-  artifactDetail,
-  type ArtifactDetail,
-  type ArtifactDTO,
-} from '@feynote/prisma/types';
+import { artifactDetail, type ArtifactDTO } from '@feynote/prisma/types';
 import { artifactDetailToArtifactDTO } from '@feynote/api-services';
 
-export const getArtifacts = authenticatedProcedure.query(async ({ ctx }) => {
-  const [ownedArtifacts, sharedArtifacts] = await Promise.all([
-    prisma.artifact.findMany({
-      where: {
-        userId: ctx.session.userId,
-      },
-      ...artifactDetail,
-    }),
-    prisma.artifact.findMany({
-      where: {
-        artifactShares: {
-          some: {
-            userId: ctx.session.userId,
+export const getArtifacts = authenticatedProcedure.query(
+  async ({ ctx }): Promise<ArtifactDTO[]> => {
+    const [ownedArtifacts, sharedArtifacts] = await Promise.all([
+      prisma.artifact.findMany({
+        where: {
+          userId: ctx.session.userId,
+        },
+        ...artifactDetail,
+      }),
+      prisma.artifact.findMany({
+        where: {
+          artifactShares: {
+            some: {
+              userId: ctx.session.userId,
+            },
           },
         },
-      },
-      ...artifactDetail,
-    }),
-  ]);
+        ...artifactDetail,
+      }),
+    ]);
 
-  const artifacts = [...ownedArtifacts, ...sharedArtifacts];
+    const artifacts = [...ownedArtifacts, ...sharedArtifacts];
 
-  const results = new Map<string, ArtifactDTO>();
-  for (const artifact of artifacts) {
-    const dto = artifactDetailToArtifactDTO(
-      ctx.session.userId,
-      artifact as ArtifactDetail,
-    );
-    results.set(dto.id, dto);
-  }
+    const results = new Map<string, ArtifactDTO>();
+    for (const artifact of artifacts) {
+      const dto = artifactDetailToArtifactDTO(ctx.session.userId, artifact);
+      results.set(dto.id, dto);
+    }
 
-  return [...results.values()];
-});
+    return [...results.values()];
+  },
+);

--- a/libs/trpc/src/lib/router/artifact/searchArtifactBlocks.ts
+++ b/libs/trpc/src/lib/router/artifact/searchArtifactBlocks.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { prisma } from '@feynote/prisma/client';
 import { artifactDetail, type ArtifactDTO } from '@feynote/prisma/types';
 import { artifactDetailToArtifactDTO } from '@feynote/api-services';
+import type { BlockIndexDocument } from '@feynote/search';
 
 export const searchArtifactBlocks = authenticatedProcedure
   .input(
@@ -12,48 +13,59 @@ export const searchArtifactBlocks = authenticatedProcedure
       limit: z.number().min(1).max(100).optional(),
     }),
   )
-  .query(async ({ input, ctx }) => {
-    const matchedArtifactBlocks = await searchProvider.searchArtifactBlocks(
-      ctx.session.userId,
-      input.query,
-      {
-        prefix: true,
-      },
-    );
-
-    const matchedArtifactIds = [
-      ...new Set(
-        matchedArtifactBlocks.map((artifactBlock) => artifactBlock.artifactId),
-      ),
-    ];
-
-    const artifacts = await prisma.artifact.findMany({
-      where: {
-        id: {
-          in: matchedArtifactIds,
+  .query(
+    async ({
+      input,
+      ctx,
+    }): Promise<
+      (BlockIndexDocument & {
+        artifact: ArtifactDTO;
+      })[]
+    > => {
+      const matchedArtifactBlocks = await searchProvider.searchArtifactBlocks(
+        ctx.session.userId,
+        input.query,
+        {
+          prefix: true,
         },
-      },
-      ...artifactDetail,
-      take: input.limit || 100,
-    });
+      );
 
-    const artifactsById = artifacts.reduce<Record<string, ArtifactDTO>>(
-      (artifactsById, artifact) => {
-        artifactsById[artifact.id] = artifactDetailToArtifactDTO(
-          ctx.session.userId,
-          artifact,
-        );
-        return artifactsById;
-      },
-      {},
-    );
+      const matchedArtifactIds = [
+        ...new Set(
+          matchedArtifactBlocks.map(
+            (artifactBlock) => artifactBlock.artifactId,
+          ),
+        ),
+      ];
 
-    const results = matchedArtifactBlocks
-      .map((matchedArtifactBlock) => ({
-        ...matchedArtifactBlock,
-        artifact: artifactsById[matchedArtifactBlock.artifactId],
-      }))
-      .filter((matchedArtifactBlock) => !!matchedArtifactBlock.artifact);
+      const artifacts = await prisma.artifact.findMany({
+        where: {
+          id: {
+            in: matchedArtifactIds,
+          },
+        },
+        ...artifactDetail,
+        take: input.limit || 100,
+      });
 
-    return results;
-  });
+      const artifactsById = artifacts.reduce<Record<string, ArtifactDTO>>(
+        (artifactsById, artifact) => {
+          artifactsById[artifact.id] = artifactDetailToArtifactDTO(
+            ctx.session.userId,
+            artifact,
+          );
+          return artifactsById;
+        },
+        {},
+      );
+
+      const results = matchedArtifactBlocks
+        .map((matchedArtifactBlock) => ({
+          ...matchedArtifactBlock,
+          artifact: artifactsById[matchedArtifactBlock.artifactId],
+        }))
+        .filter((matchedArtifactBlock) => !!matchedArtifactBlock.artifact);
+
+      return results;
+    },
+  );

--- a/libs/trpc/src/lib/router/artifact/searchArtifactTitles.ts
+++ b/libs/trpc/src/lib/router/artifact/searchArtifactTitles.ts
@@ -12,7 +12,7 @@ export const searchArtifactTitles = authenticatedProcedure
       limit: z.number().min(1).max(100).optional(),
     }),
   )
-  .query(async ({ input, ctx }) => {
+  .query(async ({ input, ctx }): Promise<ArtifactDTO[]> => {
     const limit = input.limit || 100;
     const resultArtifactIds = await searchProvider.searchArtifactTitles(
       ctx.session.userId,

--- a/libs/trpc/src/lib/router/artifact/searchArtifacts.ts
+++ b/libs/trpc/src/lib/router/artifact/searchArtifacts.ts
@@ -12,7 +12,7 @@ export const searchArtifacts = authenticatedProcedure
       limit: z.number().min(1).max(100).optional(),
     }),
   )
-  .query(async ({ input, ctx }) => {
+  .query(async ({ input, ctx }): Promise<ArtifactDTO[]> => {
     const limit = input.limit || 100;
     const resultArtifactIds = await searchProvider.searchArtifacts(
       ctx.session.userId,

--- a/libs/trpc/src/lib/router/artifact/updateArtifact.ts
+++ b/libs/trpc/src/lib/router/artifact/updateArtifact.ts
@@ -10,7 +10,7 @@ export const updateArtifact = authenticatedProcedure
       id: z.string(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
+  .mutation(async ({ ctx, input }): Promise<string> => {
     const artifact = await prisma.artifact.findUnique({
       where: {
         id: input.id,

--- a/libs/trpc/src/lib/router/artifactPin/deleteArtifactPin.ts
+++ b/libs/trpc/src/lib/router/artifactPin/deleteArtifactPin.ts
@@ -8,7 +8,7 @@ export const deleteArtifactPin = authenticatedProcedure
       artifactId: z.string(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
+  .mutation(async ({ ctx, input }): Promise<string> => {
     await prisma.artifactPin.deleteMany({
       where: {
         artifactId: input.artifactId,

--- a/libs/trpc/src/lib/router/artifactShare/deleteArtifactShare.ts
+++ b/libs/trpc/src/lib/router/artifactShare/deleteArtifactShare.ts
@@ -11,7 +11,7 @@ export const deleteArtifactShare = authenticatedProcedure
       userId: z.string(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
+  .mutation(async ({ ctx, input }): Promise<string> => {
     const artifact = await prisma.artifact.findUnique({
       where: {
         id: input.artifactId,

--- a/libs/trpc/src/lib/router/artifactShareToken/createArtifactShareToken.ts
+++ b/libs/trpc/src/lib/router/artifactShareToken/createArtifactShareToken.ts
@@ -16,36 +16,43 @@ export const createArtifactShareToken = authenticatedProcedure
       expiresAt: z.date().optional(),
     }),
   )
-  .mutation(async ({ ctx, input }) => {
-    const artifact = await prisma.artifact.findUnique({
-      where: {
-        id: input.artifactId,
-        userId: ctx.session.userId,
-      },
-      select: {
-        id: true,
-      },
-    });
-
-    if (!artifact) {
-      throw new TRPCError({
-        message: 'Artifact does not exist or is not owned by current user',
-        code: 'FORBIDDEN',
+  .mutation(
+    async ({
+      ctx,
+      input,
+    }): Promise<{
+      id: string;
+    }> => {
+      const artifact = await prisma.artifact.findUnique({
+        where: {
+          id: input.artifactId,
+          userId: ctx.session.userId,
+        },
+        select: {
+          id: true,
+        },
       });
-    }
 
-    const artifactShare = await prisma.artifactShareToken.create({
-      data: {
-        artifactId: input.artifactId,
-        accessLevel: input.accessLevel,
-        shareToken: randomBytes(SHARE_TOKEN_BYTES).toString('hex'),
-        expiresAt: input.expiresAt,
-        allowAddToAccount: input.allowAddToAccount,
-      },
-      select: {
-        id: true,
-      },
-    });
+      if (!artifact) {
+        throw new TRPCError({
+          message: 'Artifact does not exist or is not owned by current user',
+          code: 'FORBIDDEN',
+        });
+      }
 
-    return artifactShare;
-  });
+      const artifactShare = await prisma.artifactShareToken.create({
+        data: {
+          artifactId: input.artifactId,
+          accessLevel: input.accessLevel,
+          shareToken: randomBytes(SHARE_TOKEN_BYTES).toString('hex'),
+          expiresAt: input.expiresAt,
+          allowAddToAccount: input.allowAddToAccount,
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      return artifactShare;
+    },
+  );

--- a/libs/trpc/src/lib/router/artifactShareToken/deleteArtifactShareToken.ts
+++ b/libs/trpc/src/lib/router/artifactShareToken/deleteArtifactShareToken.ts
@@ -14,7 +14,7 @@ export const deleteArtifactShareToken = authenticatedProcedure
       }),
     ]),
   )
-  .mutation(async ({ ctx, input }) => {
+  .mutation(async ({ ctx, input }): Promise<string> => {
     const artifactShareToken = await prisma.artifactShareToken.findFirst({
       where: {
         id: 'id' in input ? input.id : undefined,

--- a/libs/trpc/src/lib/router/user/getByEmail.ts
+++ b/libs/trpc/src/lib/router/user/getByEmail.ts
@@ -9,28 +9,36 @@ export const getByEmail = authenticatedProcedure
       email: z.string().email(),
     }),
   )
-  .query(async ({ input }) => {
-    const user = await prisma.user.findUnique({
-      where: {
-        email: input.email,
-      },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-      },
-    });
-
-    if (!user) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: 'User with that email not found',
+  .query(
+    async ({
+      input,
+    }): Promise<{
+      id: string;
+      name: string;
+      email: string;
+    }> => {
+      const user = await prisma.user.findUnique({
+        where: {
+          email: input.email,
+        },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+        },
       });
-    }
 
-    return {
-      id: user.id,
-      name: user.name,
-      email: user.email,
-    };
-  });
+      if (!user) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'User with that email not found',
+        });
+      }
+
+      return {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+      };
+    },
+  );

--- a/libs/trpc/src/lib/router/user/getKnownUsers.ts
+++ b/libs/trpc/src/lib/router/user/getKnownUsers.ts
@@ -1,25 +1,37 @@
 import { authenticatedProcedure } from '../../middleware/authenticatedProcedure';
 import { prisma } from '@feynote/prisma/client';
 
-export const getKnownUsers = authenticatedProcedure.query(async ({ ctx }) => {
-  const artifactShares = await prisma.artifactShare.findMany({
-    where: {
-      artifact: {
-        userId: ctx.session.userId,
-      },
-    },
-    select: {
-      user: {
-        select: {
-          id: true,
-          name: true,
-          email: true,
+export const getKnownUsers = authenticatedProcedure.query(
+  async ({
+    ctx,
+  }): Promise<
+    {
+      id: string;
+      name: string;
+      email: string;
+    }[]
+  > => {
+    const artifactShares = await prisma.artifactShare.findMany({
+      where: {
+        artifact: {
+          userId: ctx.session.userId,
         },
       },
-    },
-  });
+      select: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
 
-  const knownUsers = artifactShares.map((artifactShare) => artifactShare.user);
+    const knownUsers = artifactShares.map(
+      (artifactShare) => artifactShare.user,
+    );
 
-  return knownUsers;
-});
+    return knownUsers;
+  },
+);

--- a/libs/trpc/src/lib/router/user/getManifest.ts
+++ b/libs/trpc/src/lib/router/user/getManifest.ts
@@ -2,70 +2,72 @@ import { Manifest } from '@feynote/shared-utils';
 import { authenticatedProcedure } from '../../middleware/authenticatedProcedure';
 import { prisma } from '@feynote/prisma/client';
 
-export const getManifest = authenticatedProcedure.query(async ({ ctx }) => {
-  const artifactsPromise = prisma.artifact.findMany({
-    where: {
-      userId: ctx.session.userId,
-    },
-    select: {
-      id: true,
-      updatedAt: true,
-    },
-  });
+export const getManifest = authenticatedProcedure.query(
+  async ({ ctx }): Promise<Manifest> => {
+    const artifactsPromise = prisma.artifact.findMany({
+      where: {
+        userId: ctx.session.userId,
+      },
+      select: {
+        id: true,
+        updatedAt: true,
+      },
+    });
 
-  const artifactSharesPromise = prisma.artifactShare.findMany({
-    where: {
-      userId: ctx.session.userId,
-    },
-    select: {
-      artifact: {
-        select: {
-          id: true,
-          updatedAt: true,
+    const artifactSharesPromise = prisma.artifactShare.findMany({
+      where: {
+        userId: ctx.session.userId,
+      },
+      select: {
+        artifact: {
+          select: {
+            id: true,
+            updatedAt: true,
+          },
         },
       },
-    },
-  });
+    });
 
-  const [artifacts, artifactShares] = await Promise.all([
-    artifactsPromise,
-    artifactSharesPromise,
-  ]);
+    const [artifacts, artifactShares] = await Promise.all([
+      artifactsPromise,
+      artifactSharesPromise,
+    ]);
 
-  const allArtifactIds = artifacts
-    .map((artifact) => artifact.id)
-    .concat(artifactShares.map((artifactShare) => artifactShare.artifact.id));
+    const allArtifactIds = artifacts
+      .map((artifact) => artifact.id)
+      .concat(artifactShares.map((artifactShare) => artifactShare.artifact.id));
 
-  const relationships = await prisma.artifactReference.findMany({
-    where: {
-      artifactId: {
-        in: allArtifactIds,
+    const relationships = await prisma.artifactReference.findMany({
+      where: {
+        artifactId: {
+          in: allArtifactIds,
+        },
+        targetArtifactId: {
+          in: allArtifactIds,
+        },
       },
-      targetArtifactId: {
-        in: allArtifactIds,
+      select: {
+        artifactId: true,
+        artifactBlockId: true,
+        targetArtifactId: true,
+        targetArtifactBlockId: true,
+        referenceText: true,
       },
-    },
-    select: {
-      artifactId: true,
-      artifactBlockId: true,
-      targetArtifactId: true,
-      targetArtifactBlockId: true,
-      referenceText: true,
-    },
-  });
+    });
 
-  const manifest: Manifest = {
-    edges: relationships,
-    artifactVersions: {},
-  };
+    const manifest: Manifest = {
+      edges: relationships,
+      artifactVersions: {},
+    };
 
-  for (const artifact of artifacts) {
-    manifest.artifactVersions[artifact.id] = artifact.updatedAt.getTime();
-  }
-  for (const artifactShare of artifactShares) {
-    manifest.artifactVersions[artifactShare.artifact.id] =
-      artifactShare.artifact.updatedAt.getTime();
-  }
+    for (const artifact of artifacts) {
+      manifest.artifactVersions[artifact.id] = artifact.updatedAt.getTime();
+    }
+    for (const artifactShare of artifactShares) {
+      manifest.artifactVersions[artifactShare.artifact.id] =
+        artifactShare.artifact.updatedAt.getTime();
+    }
 
-  return manifest;
-});
+    return manifest;
+  },
+);

--- a/libs/trpc/src/lib/router/user/getPreferences.ts
+++ b/libs/trpc/src/lib/router/user/getPreferences.ts
@@ -2,19 +2,21 @@ import { AppPreferences } from '@feynote/shared-utils';
 import { authenticatedProcedure } from '../../middleware/authenticatedProcedure';
 import { prisma } from '@feynote/prisma/client';
 
-export const getPreferences = authenticatedProcedure.query(async ({ ctx }) => {
-  const user = await prisma.user.findUniqueOrThrow({
-    where: {
-      id: ctx.session.userId,
-    },
-    select: {
-      preferences: true,
-    },
-  });
+export const getPreferences = authenticatedProcedure.query(
+  async ({ ctx }): Promise<AppPreferences | null> => {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: {
+        id: ctx.session.userId,
+      },
+      select: {
+        preferences: true,
+      },
+    });
 
-  // Cast to unknown since there is no good way of typing prisma json fields
-  // Field is optional, so nullable
-  const preferences = user.preferences as unknown as AppPreferences | null;
+    // Cast to unknown since there is no good way of typing prisma json fields
+    // Field is optional, so nullable
+    const preferences = user.preferences as unknown as AppPreferences | null;
 
-  return preferences;
-});
+    return preferences;
+  },
+);

--- a/libs/trpc/src/lib/router/user/login.ts
+++ b/libs/trpc/src/lib/router/user/login.ts
@@ -7,6 +7,7 @@ import {
   UserNotFoundError,
 } from '@feynote/api-services';
 import { TRPCError } from '@trpc/server';
+import { SessionDTO } from '@feynote/shared-utils';
 
 export const login = publicProcedure
   .input(
@@ -15,7 +16,7 @@ export const login = publicProcedure
       password: z.string(),
     }),
   )
-  .mutation(async ({ input }) => {
+  .mutation(async ({ input }): Promise<SessionDTO> => {
     try {
       const session = await services.login(input.email, input.password);
       return session;

--- a/libs/trpc/src/lib/router/user/register.ts
+++ b/libs/trpc/src/lib/router/user/register.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 import * as services from '@feynote/api-services';
 import { UserAlreadyExistError } from '@feynote/api-services';
 import { TRPCError } from '@trpc/server';
-import { validateEmail, validatePassword } from '@feynote/shared-utils';
+import {
+  SessionDTO,
+  validateEmail,
+  validatePassword,
+} from '@feynote/shared-utils';
 
 export const register = publicProcedure
   .input(
@@ -13,7 +17,7 @@ export const register = publicProcedure
       password: z.string().refine(validatePassword),
     }),
   )
-  .mutation(async ({ input }) => {
+  .mutation(async ({ input }): Promise<SessionDTO> => {
     try {
       const session = await services.register(
         input.name,

--- a/libs/trpc/src/lib/router/user/setPreferences.ts
+++ b/libs/trpc/src/lib/router/user/setPreferences.ts
@@ -29,7 +29,7 @@ export const setPreferences = authenticatedProcedure
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) satisfies z.ZodSchema<AppPreferences, any, any>,
   )
-  .mutation(async ({ ctx, input }) => {
+  .mutation(async ({ ctx, input }): Promise<string> => {
     await prisma.user.update({
       where: {
         id: ctx.session.userId,

--- a/libs/trpc/src/lib/router/user/signInWithGoogle.ts
+++ b/libs/trpc/src/lib/router/user/signInWithGoogle.ts
@@ -12,7 +12,7 @@ export const signInWithGoogle = publicProcedure
       credential: z.string(),
     }),
   )
-  .mutation(async ({ input }) => {
+  .mutation(async ({ input }): Promise<SessionDTO> => {
     const { clientId, credential } = input;
     const client = new OAuth2Client();
     const ticket = await client.verifyIdToken({

--- a/libs/trpc/src/lib/router/user/triggerPasswordReset.ts
+++ b/libs/trpc/src/lib/router/user/triggerPasswordReset.ts
@@ -9,6 +9,6 @@ export const triggerPasswordReset = publicProcedure
       returnUrl: z.string(),
     }),
   )
-  .mutation(({ input }) => {
+  .mutation(({ input }): Promise<void> => {
     return services.triggerPasswordReset(input.email, input.returnUrl);
   });


### PR DESCRIPTION
Fixed by not sharing prisma derived dynamic types to frontend through tRPC.

Next improvement would be eliminating Zod type inference which is wildly recognized as slow.