### PR TITLE
feat: filter empty target blocks, filter self references, dedupe refences

### DIFF
--- a/libs/prisma/types/src/lib/types/ArtifactDTO.ts
+++ b/libs/prisma/types/src/lib/types/ArtifactDTO.ts
@@ -27,6 +27,9 @@ export type ArtifactDTO = {
     targetArtifactId: string;
     targetArtifactBlockId: string | null;
     referenceTargetArtifactId: string | null;
+    targetArtifact: {
+      title: string;
+    } | null;
     referenceText: string;
     targetArtifactDate: string | null;
   }[];

--- a/libs/prisma/types/src/lib/types/artifactDetail.ts
+++ b/libs/prisma/types/src/lib/types/artifactDetail.ts
@@ -18,6 +18,11 @@ export const artifactDetail = Prisma.validator<Prisma.ArtifactArgs>()({
         targetArtifactId: true,
         targetArtifactBlockId: true,
         referenceTargetArtifactId: true,
+        targetArtifact: {
+          select: {
+            title: true,
+          },
+        },
         referenceText: true,
         targetArtifactDate: true,
       },

--- a/libs/ui/src/components/artifact/ArtifactRightSidemenu.tsx
+++ b/libs/ui/src/components/artifact/ArtifactRightSidemenu.tsx
@@ -108,6 +108,42 @@ export const ArtifactRightSidemenu: React.FC<Props> = (props) => {
     [props.artifact, session.userId],
   );
 
+  const incomingArtifactReferenceTitles = useMemo(
+    () =>
+      Object.entries(
+        props.artifact.incomingArtifactReferences.reduce<{
+          [key: string]: string;
+        }>((acc, el) => {
+          // We don't want to show self-references in the incoming artifact references list
+          if (el.artifactId === props.artifact.id) return acc;
+
+          acc[el.artifactId] = el.artifact.title;
+          return acc;
+        }, {}),
+      ),
+    [props.artifact],
+  );
+
+  const artifactReferenceTitles = useMemo(
+    () =>
+      Object.entries(
+        props.artifact.artifactReferences.reduce<{ [key: string]: string }>(
+          (acc, el) => {
+            // We don't want to show broken references in the referenced artifact list
+            if (!el.targetArtifact) return acc;
+
+            // We don't want to show self-references in the referenced artifact list
+            if (el.targetArtifactId === props.artifact.id) return acc;
+
+            acc[el.targetArtifactId] = el.targetArtifact.title;
+            return acc;
+          },
+          {},
+        ),
+      ),
+    [props.artifact],
+  );
+
   return (
     <>
       <IonCard>
@@ -210,7 +246,7 @@ export const ArtifactRightSidemenu: React.FC<Props> = (props) => {
           </CompactIonItem>
         </IonCard>
       )}
-      {!!props.artifact.incomingArtifactReferences.length && (
+      {!!incomingArtifactReferenceTitles.length && (
         <IonCard>
           <IonListHeader>
             <IonIcon icon={link} size="small" />
@@ -220,25 +256,27 @@ export const ArtifactRightSidemenu: React.FC<Props> = (props) => {
               message={t('artifactRenderer.incomingArtifactReferences.help')}
             />
           </IonListHeader>
-          {props.artifact.incomingArtifactReferences.map((el) => (
-            <CompactIonItem
-              lines="none"
-              key={el.id}
-              onClick={() =>
-                navigate(
-                  PaneableComponent.Artifact,
-                  { id: el.artifactId },
-                  PaneTransition.Push,
-                )
-              }
-              button
-            >
-              <NowrapIonLabel>{el.artifact.title}</NowrapIonLabel>
-            </CompactIonItem>
-          ))}
+          {incomingArtifactReferenceTitles.map(
+            ([otherArtifactId, otherArtifactTitle]) => (
+              <CompactIonItem
+                lines="none"
+                key={otherArtifactId}
+                onClick={() =>
+                  navigate(
+                    PaneableComponent.Artifact,
+                    { id: otherArtifactId },
+                    PaneTransition.Push,
+                  )
+                }
+                button
+              >
+                <NowrapIonLabel>{otherArtifactTitle}</NowrapIonLabel>
+              </CompactIonItem>
+            ),
+          )}
         </IonCard>
       )}
-      {!!props.artifact.artifactReferences.length && (
+      {!!artifactReferenceTitles.length && (
         <IonCard>
           <IonListHeader>
             <IonIcon icon={link} size="small" />
@@ -248,22 +286,24 @@ export const ArtifactRightSidemenu: React.FC<Props> = (props) => {
               message={t('artifactRenderer.artifactReferences.help')}
             />
           </IonListHeader>
-          {props.artifact.artifactReferences.map((el) => (
-            <CompactIonItem
-              lines="none"
-              key={el.id}
-              onClick={() =>
-                navigate(
-                  PaneableComponent.Artifact,
-                  { id: el.artifactId },
-                  PaneTransition.Push,
-                )
-              }
-              button
-            >
-              <NowrapIonLabel>{el.referenceText}</NowrapIonLabel>
-            </CompactIonItem>
-          ))}
+          {artifactReferenceTitles.map(
+            ([otherArtifactId, otherArtifactTitle]) => (
+              <CompactIonItem
+                lines="none"
+                key={otherArtifactId}
+                onClick={() =>
+                  navigate(
+                    PaneableComponent.Artifact,
+                    { id: otherArtifactId },
+                    PaneTransition.Push,
+                  )
+                }
+                button
+              >
+                <NowrapIonLabel>{otherArtifactTitle}</NowrapIonLabel>
+              </CompactIonItem>
+            ),
+          )}
         </IonCard>
       )}
     </>

--- a/libs/ui/src/components/editor/tiptap/extensions/artifactReferences/getReferenceSuggestions.ts
+++ b/libs/ui/src/components/editor/tiptap/extensions/artifactReferences/getReferenceSuggestions.ts
@@ -40,6 +40,8 @@ export const getReferenceSuggestions = async ({
   }
 
   for (const block of blocks) {
+    if (!block.text.trim() || block.text.trim().startsWith('@')) continue;
+
     suggestionItems.push({
       artifactId: block.artifactId,
       artifactBlockId: block.id,


### PR DESCRIPTION
- Filters empty target blocks in search results
- Do not show self references in references list in right side menu (still allowed to create self references though)
- Dedupe references in right side menu and show artifact title rather than text in right side menu