### PR TITLE
fix: ai threads invalid returntype

### DIFF
--- a/libs/trpc/src/lib/router/ai/getThread.ts
+++ b/libs/trpc/src/lib/router/ai/getThread.ts
@@ -24,10 +24,21 @@ export const getThread = authenticatedProcedure
     const threadDTO = {
       id: thread.id,
       title: thread.title || undefined,
-      messages: (thread.messages as unknown as ThreadDTOMessage[]).filter(
-        (message) =>
-          message.json.role === 'user' || message.json.role === 'assistant',
-      ),
+      messages: (thread.messages as unknown as ThreadDTOMessage[])
+        .filter(
+          (message) =>
+            message.json.role === 'user' || message.json.role === 'assistant',
+        )
+        .map((message) => ({
+          id: message.id,
+          json: {
+            ...message.json,
+            createdAt: message.json.createdAt
+              ? new Date(message.json.createdAt)
+              : undefined,
+          },
+          createdAt: message.createdAt,
+        })),
     };
     return threadDTO satisfies ThreadDTO;
   });

--- a/libs/trpc/src/lib/router/ai/getThreads.ts
+++ b/libs/trpc/src/lib/router/ai/getThreads.ts
@@ -13,7 +13,18 @@ export const getThreads = authenticatedProcedure.query(
     const threadDTOs = threads.map((thread) => ({
       id: thread.id,
       title: thread.title || undefined,
-      messages: thread.messages as unknown as ThreadDTOMessage[],
+      messages: (thread.messages as unknown as ThreadDTOMessage[]).map(
+        (message) => ({
+          id: message.id,
+          json: {
+            ...message.json,
+            createdAt: message.json.createdAt
+              ? new Date(message.json.createdAt)
+              : undefined,
+          },
+          createdAt: message.createdAt,
+        }),
+      ),
     }));
 
     return threadDTOs satisfies ThreadDTO[];


### PR DESCRIPTION
Fixes a typings issue from casting to `as unknown as` which covered up a real serialization issue that crashes prod.