### PR TITLE
fix: ai thread not working in Chrome

### DIFF
--- a/libs/ui/src/components/assistant/AIThread.tsx
+++ b/libs/ui/src/components/assistant/AIThread.tsx
@@ -162,7 +162,6 @@ export const AIThread: React.FC<Props> = (props) => {
         api: `${getApiUrls().rest}/message/`,
         headers: {
           Authorization: `Bearer ${sessionContext.session.token}`,
-          'Content-Type': 'application/json',
         },
         body: {
           threadId: props.id,


### PR DESCRIPTION
1. AIThread.tsx passed 'Content-Type': 'application/json'
2. AI SDK runs all caller-provided headers through normalizeHeaders(), which lowercases all keys
3. Then in AI SDK builds the fetch headers as: `headers: { 'Content-Type': 'application/json', ...headers }`
4. Since JS object keys are case-sensitive, 'Content-Type' and 'content-type' are treated as two different keys, so both end up in the headers
5. Firefox dedupes the headers while Chrome concatenates them so it ends up as `application/json, application/json` in Chrome

TL;DR - this is AI SDK's fault