### PR TITLE
fix: add workspace owner to artifact when saying yes to sharing

### DIFF
--- a/apps/frontend/public/locales/en-us.json
+++ b/apps/frontend/public/locales/en-us.json
@@ -556,6 +556,7 @@
   "artifactSharing.noaccess": "No Access",
   "artifactSharing.readwrite": "Read & Write",
   "artifactSharing.readonly": "Read Only",
+  "artifactSharing.coowner": "Co-owner",
   "artifactSharing.link": "Public Access via Link",
   "artifactSharing.link.help": "A link makes it easy for you to send an document via other platforms. When you enable link visibility, anyone with the link will be able to access the content you've created within your document.",
   "artifactSharing.link.accessLevel": "Link Access",

--- a/libs/ui/src/components/artifact/ArtifactSharingAccessLevel.tsx
+++ b/libs/ui/src/components/artifact/ArtifactSharingAccessLevel.tsx
@@ -6,7 +6,7 @@ export const accessLevelI18n = {
   noaccess: 'artifactSharing.noaccess',
   readwrite: 'artifactSharing.readwrite',
   readonly: 'artifactSharing.readonly',
-  coowner: 'artifactSharing.readonly',
+  coowner: 'artifactSharing.coowner',
 } satisfies Record<ArtifactAccessLevel, string>;
 
 interface ArtifactSharingAccessLevelSelectProps {

--- a/libs/ui/src/utils/workspace/addArtifactToWorkspaceWithSharingPrompt.ts
+++ b/libs/ui/src/utils/workspace/addArtifactToWorkspaceWithSharingPrompt.ts
@@ -45,6 +45,13 @@ export const addArtifactToWorkspaceWithSharingPrompt = async (opts: {
         .toArray()
         .filter((m) => m.val.accessLevel !== 'noaccess');
 
+      if (meta.userId && !workspaceMembers.some((m) => m.key === meta.userId)) {
+        workspaceMembers.push({
+          key: meta.userId,
+          val: { accessLevel: 'readwrite' },
+        });
+      }
+
       const artifacts = getWorkspaceArtifactsFromYDoc(connection.yjsDoc);
 
       canEditWorkspace =


### PR DESCRIPTION
Also adds an i18n string for co-owner since it was missing. At some point we should consider adding the UI for adding a co-owner for a document. It'd need more testing before we did that, though.